### PR TITLE
Fix using sprintf for extending string, which causes undefined behavior.

### DIFF
--- a/core/rtw_mp.c
+++ b/core/rtw_mp.c
@@ -1871,7 +1871,7 @@ u32 mp_query_psd(PADAPTER pAdapter, u8 *data)
 		} else {
 			psd_data = rtw_GetPSDData(pAdapter, i);
 		}
-		sprintf(data, "%s%x ", data, psd_data);
+		sprintf(data + strlen(data), "%x ", psd_data);
 		i++;
 	}
 

--- a/os_dep/linux/ioctl_linux.c
+++ b/os_dep/linux/ioctl_linux.c
@@ -9080,19 +9080,19 @@ static int rtw_mp_efuse_get(struct net_device *dev,
 		sprintf(extra, "\n");
 		for (i = 0; i < EFUSE_MAP_SIZE; i += 16) {
 //			DBG_871X("0x%02x\t", i);
-			sprintf(extra, "%s0x%02x\t", extra, i);
+			sprintf(extra + strlen(extra), "0x%02x\t", i);
 			for (j=0; j<8; j++) {
 //				DBG_871X("%02X ", data[i+j]);
-				sprintf(extra, "%s%02X ", extra, PROMContent[i+j]);
+				sprintf(extra + strlen(extra), "%02X ", PROMContent[i+j]);
 			}
 //			DBG_871X("\t");
-			sprintf(extra, "%s\t", extra);
+			sprintf(extra + strlen(extra), "\t");
 			for (; j<16; j++) {
 //				DBG_871X("%02X ", data[i+j]);
-				sprintf(extra, "%s%02X ", extra, PROMContent[i+j]);
+				sprintf(extra + strlen(extra), "%02X ", PROMContent[i+j]);
 			}
 //			DBG_871X("\n");
-			sprintf(extra,"%s\n",extra);
+			sprintf(extra + strlen(extra), "\n");
 		}
 //		DBG_871X("\n");
 	} else if (strcmp(tmp[0], "realmap") == 0) {
@@ -9107,19 +9107,19 @@ static int rtw_mp_efuse_get(struct net_device *dev,
 		sprintf(extra, "\n");
 		for (i = 0; i < EFUSE_MAP_SIZE; i += 16) {
 //			DBG_871X("0x%02x\t", i);
-			sprintf(extra, "%s0x%02x\t", extra, i);
+			sprintf(extra + strlen(extra), "0x%02x\t", i);
 			for (j=0; j<8; j++) {
 //				DBG_871X("%02X ", data[i+j]);
-				sprintf(extra, "%s%02X ", extra, pEfuseHal->fakeEfuseInitMap[i+j]);
+				sprintf(extra + strlen(extra), "%02X ", pEfuseHal->fakeEfuseInitMap[i+j]);
 			}
 //			DBG_871X("\t");
-			sprintf(extra, "%s\t", extra);
+			sprintf(extra + strlen(extra), "\t");
 			for (; j<16; j++) {
 //				DBG_871X("%02X ", data[i+j]);
-				sprintf(extra, "%s%02X ", extra, pEfuseHal->fakeEfuseInitMap[i+j]);
+				sprintf(extra + strlen(extra), "%02X ", pEfuseHal->fakeEfuseInitMap[i+j]);
 			}
 //			DBG_871X("\n");
-			sprintf(extra,"%s\n",extra);
+			sprintf(extra + strlen(extra), "\n");
 		}
 //		DBG_871X("\n");
 	} else if (strcmp(tmp[0], "rmap") == 0) {
@@ -9158,7 +9158,7 @@ static int rtw_mp_efuse_get(struct net_device *dev,
 		*extra = 0;
 		for (i=0; i<cnts; i++) {
 //			DBG_871X("0x%02x ", data[i]);
-			sprintf(extra, "%s0x%02X ", extra, data[i]);
+			sprintf(extra + strlen(extra), "0x%02X ", data[i]);
 		}
 //		DBG_871X("}\n");
 	} else if (strcmp(tmp[0], "realraw") == 0) {
@@ -9174,17 +9174,17 @@ static int rtw_mp_efuse_get(struct net_device *dev,
 		sprintf(extra, "\n0x00\t");
 		for (i=0; i< mapLen; i++) {
 			//			DBG_871X("%02X", rawdata[i]);
-			sprintf(extra, "%s%02X", extra, rawdata[i]);
+			sprintf(extra + strlen(extra), "%02X", rawdata[i]);
 			if ((i & 0xF) == 0xF) {
 				//				DBG_871X("\n");
-				sprintf(extra, "%s\n", extra);
-				sprintf(extra, "%s0x%02x\t", extra, i+1);
+				sprintf(extra + strlen(extra), "\n");
+				sprintf(extra + strlen(extra), "0x%02x\t", i+1);
 			} else if ((i & 0x7) == 0x7) {
 				//				DBG_871X("\t");
-				sprintf(extra, "%s \t", extra);
+				sprintf(extra + strlen(extra), " \t");
 			} else {
 				//				DBG_871X(" ");
-				sprintf(extra, "%s ", extra);
+				sprintf(extra + strlen(extra), " ");
 			}
 		}
 		//		DBG_871X("}\n");
@@ -9269,10 +9269,10 @@ static int rtw_mp_efuse_get(struct net_device *dev,
 		*extra = 0;
 		for (i=0; i<cnts; i++) {
 //			DBG_871X("%02X", data[i]);
-			sprintf(extra, "%s%02X", extra, data[i]);
+			sprintf(extra + strlen(extra), "%02X", data[i]);
 			if (i != (cnts-1)) {
 //				DBG_871X(":");
-				sprintf(extra,"%s:",extra);
+				sprintf(extra + strlen(extra), ":");
 			}
 		}
 //		DBG_871X("}\n");
@@ -9330,10 +9330,10 @@ static int rtw_mp_efuse_get(struct net_device *dev,
 		*extra = 0;
 		for (i=0; i<cnts; i++) {
 //			DBG_871X("0x%02x", data[i]);
-			sprintf(extra, "%s0x%02X", extra, data[i]);
+			sprintf(extra + strlen(extra), "0x%02X", data[i]);
 			if (i != (cnts-1)) {
 //				DBG_871X(",");
-				sprintf(extra,"%s,",extra);
+				sprintf(extra + strlen(extra), ",");
 			}
 		}
 //		DBG_871X("}\n");
@@ -9355,19 +9355,19 @@ static int rtw_mp_efuse_get(struct net_device *dev,
 		sprintf(extra, "\n");
 		for (i=0; i<512; i+=16) { // set 512 because the iwpriv's extra size have limit 0x7FF
 //			DBG_871X("0x%03x\t", i);
-			sprintf(extra, "%s0x%03x\t", extra, i);
+			sprintf(extra + strlen(extra), "0x%03x\t", i);
 			for (j=0; j<8; j++) {
 //				DBG_871X("%02X ", pEfuseHal->BTEfuseInitMap[i+j]);
-				sprintf(extra, "%s%02X ", extra, pEfuseHal->BTEfuseInitMap[i+j]);
+				sprintf(extra + strlen(extra), "%02X ", pEfuseHal->BTEfuseInitMap[i+j]);
 			}
 //			DBG_871X("\t");
-			sprintf(extra,"%s\t",extra);
+			sprintf(extra + strlen(extra), "\t");
 			for (; j<16; j++) {
 //				DBG_871X("%02X ", pEfuseHal->BTEfuseInitMap[i+j]);
-				sprintf(extra, "%s%02X ", extra, pEfuseHal->BTEfuseInitMap[i+j]);
+				sprintf(extra + strlen(extra), "%02X ", pEfuseHal->BTEfuseInitMap[i+j]);
 			}
 //			DBG_871X("\n");
-			sprintf(extra, "%s\n", extra);
+			sprintf(extra + strlen(extra), "\n");
 		}
 //		DBG_871X("\n");
 	} else if (strcmp(tmp[0],"btbmap") == 0) {
@@ -9384,19 +9384,19 @@ static int rtw_mp_efuse_get(struct net_device *dev,
 		sprintf(extra, "\n");
 		for (i=512; i<1024 ; i+=16) {
 //			DBG_871X("0x%03x\t", i);
-			sprintf(extra, "%s0x%03x\t", extra, i);
+			sprintf(extra + strlen(extra), "0x%03x\t", i);
 			for (j=0; j<8; j++) {
 //				DBG_871X("%02X ", data[i+j]);
-				sprintf(extra, "%s%02X ", extra, pEfuseHal->BTEfuseInitMap[i+j]);
+				sprintf(extra + strlen(extra), "%02X ", pEfuseHal->BTEfuseInitMap[i+j]);
 			}
 //			DBG_871X("\t");
-			sprintf(extra,"%s\t",extra);
+			sprintf(extra + strlen(extra), "\t");
 			for (; j<16; j++) {
 //				DBG_871X("%02X ", data[i+j]);
-				sprintf(extra, "%s%02X ", extra, pEfuseHal->BTEfuseInitMap[i+j]);
+				sprintf(extra + strlen(extra), "%02X ", pEfuseHal->BTEfuseInitMap[i+j]);
 			}
 //			DBG_871X("\n");
-			sprintf(extra, "%s\n", extra);
+			sprintf(extra + strlen(extra), "\n");
 		}
 //		DBG_871X("\n");
 	} else if (strcmp(tmp[0],"btrmap") == 0) {
@@ -9436,7 +9436,7 @@ static int rtw_mp_efuse_get(struct net_device *dev,
 //		DBG_871X("%s: bt efuse data={", __FUNCTION__);
 		for (i=0; i<cnts; i++) {
 //			DBG_871X("0x%02x ", data[i]);
-			sprintf(extra, "%s 0x%02X ", extra, data[i]);
+			sprintf(extra + strlen(extra), " 0x%02X ", data[i]);
 		}
 //		DBG_871X("}\n");
 		DBG_871X(FUNC_ADPT_FMT ": BT MAC=[%s]\n", FUNC_ADPT_ARG(padapter), extra);
@@ -9445,19 +9445,19 @@ static int rtw_mp_efuse_get(struct net_device *dev,
 		sprintf(extra, "\n");
 		for (i=0; i<512; i+=16) {
 //			DBG_871X("0x%03x\t", i);
-			sprintf(extra, "%s0x%03x\t", extra, i);
+			sprintf(extra + strlen(extra), "0x%03x\t", i);
 			for (j=0; j<8; j++) {
 //				DBG_871X("%02X ", pEfuseHal->fakeBTEfuseModifiedMap[i+j]);
-				sprintf(extra, "%s%02X ", extra, pEfuseHal->fakeBTEfuseModifiedMap[i+j]);
+				sprintf(extra + strlen(extra), "%02X ", pEfuseHal->fakeBTEfuseModifiedMap[i+j]);
 			}
 //			DBG_871X("\t");
-			sprintf(extra, "%s\t", extra);
+			sprintf(extra + strlen(extra), "\t");
 			for (; j<16; j++) {
 //				DBG_871X("%02X ", pEfuseHal->fakeBTEfuseModifiedMap[i+j]);
-				sprintf(extra, "%s%02X ", extra, pEfuseHal->fakeBTEfuseModifiedMap[i+j]);
+				sprintf(extra + strlen(extra), "%02X ", pEfuseHal->fakeBTEfuseModifiedMap[i+j]);
 			}
 //			DBG_871X("\n");
-			sprintf(extra, "%s\n", extra);
+			sprintf(extra + strlen(extra), "\n");
 		}
 //		DBG_871X("\n");
 	} else if (strcmp(tmp[0],"btbfake") == 0) {
@@ -9465,19 +9465,19 @@ static int rtw_mp_efuse_get(struct net_device *dev,
 		sprintf(extra, "\n");
 		for (i=512; i<1024; i+=16) {
 //			DBG_871X("0x%03x\t", i);
-			sprintf(extra, "%s0x%03x\t", extra, i);
+			sprintf(extra + strlen(extra), "0x%03x\t", i);
 			for (j=0; j<8; j++) {
 //				DBG_871X("%02X ", pEfuseHal->fakeBTEfuseModifiedMap[i+j]);
-				sprintf(extra, "%s%02X ", extra, pEfuseHal->fakeBTEfuseModifiedMap[i+j]);
+				sprintf(extra + strlen(extra), "%02X ", pEfuseHal->fakeBTEfuseModifiedMap[i+j]);
 			}
 //			DBG_871X("\t");
-			sprintf(extra, "%s\t", extra);
+			sprintf(extra + strlen(extra), "\t");
 			for (; j<16; j++) {
 //				DBG_871X("%02X ", pEfuseHal->fakeBTEfuseModifiedMap[i+j]);
-				sprintf(extra, "%s%02X ", extra, pEfuseHal->fakeBTEfuseModifiedMap[i+j]);
+				sprintf(extra + strlen(extra), "%02X ", pEfuseHal->fakeBTEfuseModifiedMap[i+j]);
 			}
 //			DBG_871X("\n");
-			sprintf(extra, "%s\n", extra);
+			sprintf(extra + strlen(extra), "\n");
 		}
 //		DBG_871X("\n");
 	} else if (strcmp(tmp[0],"wlrfkmap")== 0) {
@@ -9485,19 +9485,19 @@ static int rtw_mp_efuse_get(struct net_device *dev,
 		sprintf(extra, "\n");
 		for (i=0; i<EFUSE_MAP_SIZE; i+=16) {
 //			DBG_871X("\t0x%02x\t", i);
-			sprintf(extra, "%s0x%02x\t", extra, i);
+			sprintf(extra + strlen(extra), "0x%02x\t", i);
 			for (j=0; j<8; j++) {
 //				DBG_871X("%02X ", pEfuseHal->fakeEfuseModifiedMap[i+j]);
-				sprintf(extra, "%s%02X ", extra, pEfuseHal->fakeEfuseModifiedMap[i+j]);
+				sprintf(extra + strlen(extra), "%02X ", pEfuseHal->fakeEfuseModifiedMap[i+j]);
 			}
 //			DBG_871X("\t");
-			sprintf(extra, "%s\t", extra);
+			sprintf(extra + strlen(extra), "\t");
 			for (; j<16; j++) {
 //				DBG_871X("%02X ", pEfuseHal->fakeEfuseModifiedMap[i+j]);
-				sprintf(extra, "%s %02X", extra, pEfuseHal->fakeEfuseModifiedMap[i+j]);
+				sprintf(extra + strlen(extra), " %02X", pEfuseHal->fakeEfuseModifiedMap[i+j]);
 			}
 //			DBG_871X("\n");
-			sprintf(extra, "%s\n", extra);
+			sprintf(extra + strlen(extra), "\n");
 		}
 //		DBG_871X("\n");
 
@@ -9523,7 +9523,7 @@ static int rtw_mp_efuse_get(struct net_device *dev,
 		*extra = 0;
 		for (i=0; i<cnts; i++) {
 			DBG_871X("wlrfkrmap = 0x%02x \n", pEfuseHal->fakeEfuseModifiedMap[addr+i]);
-			sprintf(extra, "%s0x%02X ", extra, pEfuseHal->fakeEfuseModifiedMap[addr+i]);
+			sprintf(extra + strlen(extra), "0x%02X ", pEfuseHal->fakeEfuseModifiedMap[addr+i]);
 		}
 	} else if (strcmp(tmp[0],"btrfkrmap")== 0) {
 		if ((tmp[1]==NULL) || (tmp[2]==NULL)) {
@@ -9547,7 +9547,7 @@ static int rtw_mp_efuse_get(struct net_device *dev,
 		*extra = 0;
 		for (i=0; i<cnts; i++) {
 			DBG_871X("wlrfkrmap = 0x%02x \n", pEfuseHal->fakeBTEfuseModifiedMap[addr+i]);
-			sprintf(extra, "%s0x%02X ", extra, pEfuseHal->fakeBTEfuseModifiedMap[addr+i]);
+			sprintf(extra + strlen(extra), "0x%02X ", pEfuseHal->fakeBTEfuseModifiedMap[addr+i]);
 		}
 	} else {
 		sprintf(extra, "Command not found!");
@@ -10409,7 +10409,7 @@ static int rtw_mp_read_reg(struct net_device *dev,
 			pnext++;
 			if ( *pnext != '\0' ) {
 				strtout = simple_strtoul (pnext , &ptmp, 16);
-				sprintf( extra, "%s %d" ,extra ,strtout );
+				sprintf(extra + strlen(extra), " %d"  ,strtout );
 			} else {
 				break;
 			}
@@ -10443,7 +10443,7 @@ static int rtw_mp_read_reg(struct net_device *dev,
 			pnext++;
 			if ( *pnext != '\0' ) {
 				strtout = simple_strtoul (pnext , &ptmp, 16);
-				sprintf( extra, "%s %d" ,extra ,strtout );
+				sprintf(extra + strlen(extra), " %d"  ,strtout );
 			} else {
 				break;
 			}
@@ -10566,7 +10566,7 @@ static int rtw_mp_read_rf(struct net_device *dev,
 		pnext++;
 		if ( *pnext != '\0' ) {
 			strtou = simple_strtoul (pnext , &ptmp, 16);
-			sprintf( extra, "%s %d" ,extra ,strtou );
+			sprintf(extra + strlen(extra), " %d"  ,strtou );
 		} else {
 			break;
 		}
@@ -12155,14 +12155,14 @@ todo:
 				goto exit;
 
 #ifdef CONFIG_RTL8723A
-			sprintf(extra, "%s %d ", extra, (pMptCtx->mptOutBuf[i]& 0x3f));
+			sprintf(extra + strlen(extra), " %d ", (pMptCtx->mptOutBuf[i]& 0x3f));
 #else
-			sprintf(extra, "%s %d ", extra, (pMptCtx->mptOutBuf[i]& 0x1f));
+			sprintf(extra + strlen(extra), " %d ", (pMptCtx->mptOutBuf[i]& 0x1f));
 #endif
 		}
 	} else {
 		for (i=4; i<pMptCtx->mptOutLen; i++) {
-			sprintf(extra, "%s 0x%x ", extra, pMptCtx->mptOutBuf[i]);
+			sprintf(extra + strlen(extra), " 0x%x ", pMptCtx->mptOutBuf[i]);
 		}
 	}
 


### PR DESCRIPTION
Using sprintf to extend strings now cause compile time error with gcc10, on Fedora32.

I adjusted them following this : http://lkml.iu.edu/hypermail/linux/kernel/0812.0/02591.html now it builds without error.